### PR TITLE
Allow setting a custom lib path

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,6 +37,18 @@ In each download, find the following files and copy them into the
 
 Amadeus should now work correctly on PC and Mac OS.
 
+### Custom lib directory path
+
+To change the location where Amadeus looks for the FMOD libraries, you can set
+the `lib_path` argument when creating the main Amadeus object:
+
+```renpy
+python:
+  amadeus = Amadeus(lib_path='custom/path')
+```
+
+This path should be relative to the main project `game` directory.
+
 ## Android Libraries
 
 There are a few extra steps to accommodate Android builds, which involve making

--- a/amadeus.rpy
+++ b/amadeus.rpy
@@ -7,7 +7,7 @@ init python:
     Amadeus sound engine.
     """
 
-    def __init__(self, channel_limit=8, event_limit=8, version=0x00020299, default_channels=True):
+    def __init__(self, channel_limit=8, event_limit=8, version=0x00020299, default_channels=True, lib_path="amadeus/lib"):
       self.__channel_limit = channel_limit
       self.__channel_list = []
       self.__event_limit = event_limit
@@ -24,9 +24,9 @@ init python:
           self.__engine = AmadeusAndroidEngine(channel_limit, event_limit, version)
         except NameError:
           # If the jnius library isn't available, try loading the core engine instead
-          self.__engine = AmadeusCoreEngine(channel_limit, event_limit, version)
+          self.__engine = AmadeusCoreEngine(channel_limit, event_limit, version, lib_path)
       else:
-        self.__engine = AmadeusCoreEngine(channel_limit, event_limit, version)
+        self.__engine = AmadeusCoreEngine(channel_limit, event_limit, version, lib_path)
 
       # Register default channels if enabled
       if default_channels:

--- a/core_engine.rpy
+++ b/core_engine.rpy
@@ -10,7 +10,7 @@ init python:
     Primary cross-platform engine for Amadeus.
     """
 
-    def __init__(self, channel_limit, event_limit, version):
+    def __init__(self, channel_limit, event_limit, version, lib_path):
       """
       Initialize FMOD.
 
@@ -18,6 +18,7 @@ init python:
         channel_limit (int): The maximum number of channels allowed to be registered.
         event_limit (int): The maximum number of events allowed to be run at once.
         version (int): The version of FMOD loaded via the pre-compiled libraries.
+        lib_path (string): The path the the lib directory containing FMOD libs, relative to game directory.
       """
       self.__channels = {}
       self.__event_slots = {}
@@ -39,8 +40,8 @@ init python:
       else:
         raise RuntimeError('Operating system is not supported')
 
-      self.__api = CDLL(os.path.realpath(config.gamedir) + '/amadeus/lib/' + fmod_lib)
-      self.__studio_api = CDLL(os.path.realpath(config.gamedir) + '/amadeus/lib/' + fmod_studio_lib)
+      self.__api = CDLL(os.path.realpath(config.gamedir) + os.sep + lib_path + os.sep + fmod_lib)
+      self.__studio_api = CDLL(os.path.realpath(config.gamedir) + os.sep + lib_path + os.sep + fmod_studio_lib)
 
       self.__fmod = c_void_p()
       self.__call('System_Create', byref(self.__fmod), version)


### PR DESCRIPTION
This PR adds an argument to the main class to define a custom path to the FMOD libraries, relative to the game directory. 

Fixes #15 