### PR TITLE
Change init priority to ensure loading before main script

### DIFF
--- a/_engine.rpy
+++ b/_engine.rpy
@@ -1,4 +1,4 @@
-init python:
+init -999 python:
 
   from abc import ABC, abstractmethod
 

--- a/amadeus.rpy
+++ b/amadeus.rpy
@@ -1,6 +1,6 @@
 default AMADEUS_STATE = {}
 
-init python:
+init -999 python:
 
   class Amadeus():
     """

--- a/android_engine.rpy
+++ b/android_engine.rpy
@@ -1,4 +1,4 @@
-init python:
+init -999 python:
 
   if renpy.android:
     try:

--- a/channel.rpy
+++ b/channel.rpy
@@ -1,4 +1,5 @@
-init python:
+init -999 python:
+
   class AmadeusChannel:
     """
     Representation of an individual sound channel.

--- a/core_engine.rpy
+++ b/core_engine.rpy
@@ -1,4 +1,4 @@
-init python:
+init -999 python:
 
   from ctypes import *
   import platform

--- a/exception.rpy
+++ b/exception.rpy
@@ -1,4 +1,5 @@
-init python:
+init -999 python:
+
   class FMODError(RuntimeError):
     """
     Raised whenever a C library call to FMOD does not return an OK.


### PR DESCRIPTION
This PR updates the python init priority for each file to ensure that the library loads before anything in the main script which would use it.