### PR TITLE
Remove tests from being runnable by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@
 .*
 ~*
 
+# Ignore test file
+tests.rpy
+
 # Exceptions
 !.gitignore

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,9 +7,9 @@ This document will detail how to install Amadeus and get it working in your game
 Copy all files and folders in this directory into a new directory called
 "amadeus" in your project's "game" directory. 
 
-You can delete the "test.rpy" file and the "test_files" directory, as these are
-not needed to use Amadeus in your game. These files won't cause any problems,
-but they will take up extra space if you don't delete them.
+You can delete the "test.rpy.example" file and the "test_files" directory, as
+these are not needed to use Amadeus in your game. These files won't cause any
+problems, but they will take up extra space if you don't delete them.
 
 Please keep the LICENSE.txt file in this directory included in your game.
 

--- a/tests.rpy.example
+++ b/tests.rpy.example
@@ -5,6 +5,7 @@ These tests are designed to walk through the various pieces of functionality
 the engine can provide, and ensures everything is working correctly.
 """
 init:
+
   $ amadeus = Amadeus()
 
   $ amadeus.load_bank("amadeus/test_files/Master.bank")
@@ -19,6 +20,7 @@ init:
       renpy.say(None, '[[INFO] Environment Reset...')
 
 label amadeus_tests:
+
   image test_suite = "#000"
   scene test_suite
 


### PR DESCRIPTION
Originally it was believed that the `tests.rpy` would not conflict with any normal project; however, there are a few issues that do present themselves, including the test script being included in script stats, translations, etc, as well as the initial `init` block causing problems when using a different library location, etc.

This PR removes the test file by renaming it to `tests.rpy.example` and adding the `tests.rpy` file to the gitignore list.

The example file can be renamed to `tests.rpy` for development, without accidentally committing back into the project.